### PR TITLE
Refactor FEC data fetch to modular helpers

### DIFF
--- a/FECdata.fetch.transform.py
+++ b/FECdata.fetch.transform.py
@@ -4,17 +4,16 @@ import os
 from urllib.parse import urlencode
 
 # Configuration
-API_KEY = 'h3pdYZNm4O69cZIeogPkzx0keh7tBqkoPphTVntC'
-FEC_ENDPOINT = 'https://api.open.fec.gov/v1/schedules/schedule_a/'
+DEFAULT_API_KEY = 'h3pdYZNm4O69cZIeogPkzx0keh7tBqkoPphTVntC'
+API_KEY = os.getenv('FEC_API_KEY', DEFAULT_API_KEY)
+
+CONTRIBUTION_ENDPOINT = 'https://api.open.fec.gov/v1/schedules/schedule_a'
+CANDIDATE_ENDPOINT = 'https://api.open.fec.gov/v1/candidates'
+COMMITTEE_ENDPOINT = 'https://api.open.fec.gov/v1/committees'
+
 GRAPH_JSON_PATH = 'graph.json'  # Adjust this path as needed
 
-# Base parameters for the FEC API
-base_params = {
-    'api_key': API_KEY,
-    'contributor_state': 'CO',
-    'two_year_transaction_period': 2024,
-    'per_page': 100
-}
+
 
 # Load existing graph data or initialize new structure
 if os.path.exists(GRAPH_JSON_PATH) and os.path.getsize(GRAPH_JSON_PATH) > 0:
@@ -27,145 +26,167 @@ else:
 existing_node_ids = {node['id'] for node in graph['nodes']}
 existing_edges = {(e['source'], e['target'], e['label']) for e in graph['edges']}
 
-for is_individual in (True, False):
-    page = 1
-    more_pages = True
 
-    while more_pages:
-        params = base_params.copy()
-        params['is_individual'] = is_individual
-        params['page'] = page
-        full_url = FEC_ENDPOINT + '?' + urlencode(params)
-        print(f"Requesting: {full_url}")
-        response = requests.get(full_url)
-
-        try:
-            data = response.json()
-        except json.JSONDecodeError:
-            print("Error decoding JSON response.")
-            break
-
-        results = data.get('results', [])
-        print(f"Page {page}: {len(results)} results")
-
-        for item in results:
-            recipient_cmte_id = item.get('committee_id')
-            recipient_cmte_name = item.get('committee', {}).get('name')
-            cand_id = item.get('candidate_id')
-            cand_name = item.get('candidate_name')
-
-            if is_individual:
-                donor_name = item.get('contributor_name')
-                if not donor_name or not recipient_cmte_name:
+def fetch_candidates():
+    for year in (2020, 2024):
+        page = 1
+        more = True
+        while more:
+            params = {
+                'api_key': API_KEY,
+                'election_year': year,
+                'per_page': 100,
+                'page': page,
+            }
+            url = CANDIDATE_ENDPOINT + '?' + urlencode(params)
+            resp = requests.get(url)
+            try:
+                data = resp.json()
+            except json.JSONDecodeError:
+                break
+            for item in data.get('results', []):
+                cid = item.get('candidate_id')
+                name = item.get('name')
+                if not cid or not name:
                     continue
-                donor_id = f"individual_{donor_name.replace(' ', '_')}"
-                if donor_id not in existing_node_ids:
+                cycles = item.get('election_years', item.get('cycles', [])) or []
+                if cid not in existing_node_ids:
                     graph['nodes'].append({
-                        'id': donor_id,
-                        'label': donor_name,
+                        'id': cid,
+                        'label': name,
+                        'type': 'Campaign',
+                        'attributes': [
+                            {'key': 'candidate_id', 'value': cid},
+                            {'key': 'cycles', 'value': cycles},
+                        ],
+                    })
+                    existing_node_ids.add(cid)
+            pages = data.get('pagination', {}).get('pages', 1)
+            page += 1
+            more = page <= pages
+
+
+def fetch_committees():
+    for cycle in (2020, 2024):
+        page = 1
+        more = True
+        while more:
+            params = {
+                'api_key': API_KEY,
+                'cycle': cycle,
+                'per_page': 100,
+                'page': page,
+            }
+            url = COMMITTEE_ENDPOINT + '?' + urlencode(params)
+            resp = requests.get(url)
+            try:
+                data = resp.json()
+            except json.JSONDecodeError:
+                break
+            for item in data.get('results', []):
+                cmte_id = item.get('committee_id')
+                name = item.get('name')
+                if not cmte_id:
+                    continue
+                if cmte_id not in existing_node_ids:
+                    graph['nodes'].append({
+                        'id': cmte_id,
+                        'label': name,
+                        'type': 'Campaign',
+                        'attributes': [
+                            {'key': 'committee_id', 'value': cmte_id},
+                            {'key': 'cycles', 'value': item.get('cycles')},
+                        ],
+                    })
+                    existing_node_ids.add(cmte_id)
+                candidate_ids = item.get('candidate_ids') or []
+                cid = item.get('candidate_id')
+                if cid:
+                    candidate_ids.append(cid)
+                for cand in candidate_ids:
+                    if cand in existing_node_ids:
+                        edge_key = (cmte_id, cand, 'supports')
+                        if edge_key not in existing_edges:
+                            graph['edges'].append({
+                                'source': cmte_id,
+                                'target': cand,
+                                'label': 'supports',
+                            })
+                            existing_edges.add(edge_key)
+            pages = data.get('pagination', {}).get('pages', 1)
+            page += 1
+            more = page <= pages
+
+
+def fetch_contributions():
+    for period in (2020, 2024):
+        page = 1
+        more = True
+        while more:
+            params = {
+                'api_key': API_KEY,
+                'two_year_transaction_period': period,
+                'per_page': 100,
+                'page': page,
+                'contributor_state': 'CO',
+                'contributor_employer': 'jeffco',
+            }
+            url = CONTRIBUTION_ENDPOINT + '?' + urlencode(params)
+            resp = requests.get(url)
+            try:
+                data = resp.json()
+            except json.JSONDecodeError:
+                break
+            for item in data.get('results', []):
+                contrib_id = item.get('contributor_id')
+                name = item.get('contributor_name')
+                employer = item.get('contributor_employer')
+                if not contrib_id or not employer or not employer.lower().startswith('jeffco'):
+                    continue
+                if contrib_id not in existing_node_ids:
+                    graph['nodes'].append({
+                        'id': contrib_id,
+                        'label': name,
                         'type': 'Individual',
                         'attributes': [
-                            {'key': 'city', 'value': item.get('contributor_city')},
-                            {'key': 'employer', 'value': item.get('contributor_employer')},
-                            {'key': 'occupation', 'value': item.get('contributor_occupation')}
-                        ]
+                            {'key': 'address', 'value': item.get('contributor_city')},
+                            {'key': 'employer', 'value': employer},
+                        ],
                     })
-                    existing_node_ids.add(donor_id)
-            else:
-                donor_cmte_id = item.get('contributor_committee_id')
-                donor_cmte_name = item.get('contributor_name')
-                if not donor_cmte_id or not recipient_cmte_id:
-                    continue
-                donor_id = f"committee_{donor_cmte_id}"
-                if donor_id not in existing_node_ids:
-                    graph['nodes'].append({
-                        'id': donor_id,
-                        'label': donor_cmte_name,
-                        'type': 'Campaign',
-                        'attributes': [
-                            {'key': 'committee_id', 'value': donor_cmte_id}
-                        ]
-                    })
-                    existing_node_ids.add(donor_id)
+                    existing_node_ids.add(contrib_id)
+                targets = []
+                cmte = item.get('committee_id')
+                cand = item.get('candidate_id')
+                if cmte:
+                    targets.append(cmte)
+                if cand:
+                    targets.append(cand)
+                for tgt in targets:
+                    if tgt in existing_node_ids:
+                        edge_key = (contrib_id, tgt, 'contributed_to')
+                        if edge_key not in existing_edges:
+                            graph['edges'].append({
+                                'source': contrib_id,
+                                'target': tgt,
+                                'label': 'contributed_to',
+                                'type': 'Contribution',
+                                'attributes': [
+                                    {'key': 'amount', 'value': item.get('contribution_receipt_amount')},
+                                    {'key': 'date', 'value': item.get('contribution_receipt_date')},
+                                ],
+                            })
+                            existing_edges.add(edge_key)
+            pages = data.get('pagination', {}).get('pages', 1)
+            page += 1
+            more = page <= pages
 
-            if recipient_cmte_id:
-                recip_id = f"committee_{recipient_cmte_id}"
-                if recip_id not in existing_node_ids:
-                    graph['nodes'].append({
-                        'id': recip_id,
-                        'label': recipient_cmte_name,
-                        'type': 'Campaign',
-                        'attributes': [
-                            {'key': 'committee_id', 'value': recipient_cmte_id}
-                        ]
-                    })
-                    existing_node_ids.add(recip_id)
 
-            if cand_id:
-                cand_node_id = f"candidate_{cand_id}"
-                if cand_node_id not in existing_node_ids:
-                    graph['nodes'].append({
-                        'id': cand_node_id,
-                        'label': cand_name,
-                        'type': 'Campaign',
-                        'attributes': [
-                            {'key': 'candidate_id', 'value': cand_id}
-                        ]
-                    })
-                    existing_node_ids.add(cand_node_id)
-
-            if recipient_cmte_id and is_individual:
-                edge_key = (donor_id, recip_id, 'contributed_to')
-                if edge_key not in existing_edges:
-                    graph['edges'].append({
-                        'source': donor_id,
-                        'target': recip_id,
-                        'label': 'contributed_to',
-                        'type': 'Contribution',
-                        'attributes': [
-                            {'key': 'amount', 'value': item.get('contribution_receipt_amount')},
-                            {'key': 'date', 'value': item.get('contribution_receipt_date')}
-                        ]
-                    })
-                    existing_edges.add(edge_key)
-
-            if recipient_cmte_id and not is_individual:
-                edge_key = (donor_id, recip_id, 'contributed_to')
-                if edge_key not in existing_edges:
-                    graph['edges'].append({
-                        'source': donor_id,
-                        'target': recip_id,
-                        'label': 'contributed_to',
-                        'type': 'Contribution',
-                        'attributes': [
-                            {'key': 'amount', 'value': item.get('contribution_receipt_amount')},
-                            {'key': 'date', 'value': item.get('contribution_receipt_date')}
-                        ]
-                    })
-                    existing_edges.add(edge_key)
-
-            if cand_id:
-                edge_key = (donor_id, cand_node_id, 'contributed_to_candidate')
-                if edge_key not in existing_edges:
-                    graph['edges'].append({
-                        'source': donor_id,
-                        'target': cand_node_id,
-                        'label': 'contributed_to_candidate',
-                        'type': 'Contribution',
-                        'attributes': [
-                            {'key': 'amount', 'value': item.get('contribution_receipt_amount')},
-                            {'key': 'date', 'value': item.get('contribution_receipt_date')}
-                        ]
-                    })
-                    existing_edges.add(edge_key)
-
-        pagination = data.get('pagination', {})
-        total_pages = pagination.get('pages', 1)
-        page += 1
-        more_pages = page <= total_pages
+fetch_candidates()
+fetch_committees()
+fetch_contributions()
 
 # Save updated graph
 with open(GRAPH_JSON_PATH, 'w') as f:
     json.dump(graph, f, indent=2)
 
-print("Graph updated with FEC data from all pages.")
+print("Graph updated with FEC data from all sources.")


### PR DESCRIPTION
## Summary
- add ability to read `FEC_API_KEY` from the environment
- factor fetching logic into `fetch_candidates`, `fetch_committees`, and `fetch_contributions`
- query candidates, committees and contributions separately and merge results

## Testing
- `python3 -m py_compile FECdata.fetch.transform.py`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6842fa96d1688326b4371a3ce049903a