### PR TITLE
Handle graph load errors

### DIFF
--- a/FECdata.fetch.transform.py
+++ b/FECdata.fetch.transform.py
@@ -13,13 +13,12 @@ COMMITTEE_ENDPOINT = 'https://api.open.fec.gov/v1/committees'
 
 GRAPH_JSON_PATH = 'graph.json'  # Adjust this path as needed
 
-
-
-# Load existing graph data or initialize new structure
-if os.path.exists(GRAPH_JSON_PATH) and os.path.getsize(GRAPH_JSON_PATH) > 0:
+# Try loading an existing graph from disk
+try:
     with open(GRAPH_JSON_PATH, 'r') as f:
-        graph = json.load(f)
-else:
+        graph = json.load(f)  # stored nodes and edges
+except (json.JSONDecodeError, OSError):
+    # Start with an empty graph if file is missing or invalid
     graph = {'nodes': [], 'edges': []}
 
 # Use dicts for fast lookup to avoid duplicates


### PR DESCRIPTION
## Summary
- catch JSON parsing and OS errors when loading graph.json
- add short comments explaining the initialization and exception handling logic

## Testing
- `python - <<'EOF'
import json, os
GRAPH_JSON_PATH = 'graph.json'
try:
    with open(GRAPH_JSON_PATH, 'r') as f:
        graph = json.load(f)
except (json.JSONDecodeError, OSError) as e:
    graph = {'nodes': [], 'edges': []}
print(graph)
EOF`
- `python FECdata.fetch.transform.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68430b60d65083268226d66abf5460d0