### PR TITLE
Handle extended rate limits with longer retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ python3 FECdata.fetch.transform.py
 ```
 
 The script reads `graph.json` (creating it if missing) and updates it with nodes and edges from candidates, committees and contributions.
+
+API calls are retried automatically when rate limited. The tool waits up to three
+times for 60 seconds each and then performs one final retry after waiting an
+hour before giving up.


### PR DESCRIPTION
## Summary
- configure rate limit retry logic for 120 calls/minute
- retry three times with 60-second waits and a final retry after waiting an hour
- document retry behavior in README

## Testing
- `python3 -m py_compile FECdata.fetch.transform.py`
- `flake8 FECdata.fetch.transform.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684361ff09e8832692ce7730e88ee1a7