### PR TITLE
Add option to skip SSL verification for TRACER fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ This script downloads the public TRACER CSV files, parses them and appends them 
 API calls are retried automatically when rate limited. The tool waits up to three
 times for 60 seconds each and then performs one final retry after waiting an
 hour before giving up.
+
+If you see SSL certificate errors when fetching TRACER data,
+set the environment variable `VERIFY_SSL=0` to skip the check.

--- a/TRACERdata.fetch.transform.py
+++ b/TRACERdata.fetch.transform.py
@@ -6,6 +6,8 @@ import requests
 
 # Enable debug logging when the DEBUG env var is set
 DEBUG = os.getenv('DEBUG', '1') == '1'
+# Toggle SSL certificate verification with VERIFY_SSL env var
+VERIFY_SSL = os.getenv('VERIFY_SSL', '1') == '1'
 
 TRACER_BASE_URL = 'https://tracer.sos.colorado.gov/PublicSite/Download.aspx'
 # CSV export endpoints for each entity type
@@ -40,7 +42,7 @@ def download_file(url: str, dest: str) -> None:
     """Download a remote file to the local filesystem."""
     # Simple wrapper over requests.get for CSV downloads
     debug(f"Downloading {url} -> {dest}")
-    resp = requests.get(url)
+    resp = requests.get(url, verify=VERIFY_SSL)
     if resp.status_code != 200:
         print(f"Error {resp.status_code} fetching {url}")
         return


### PR DESCRIPTION
## Summary
- add `VERIFY_SSL` environment variable to toggle certificate checks
- mention the option in README

## Testing
- `python3 -m py_compile FECdata.fetch.transform.py TRACERdata.fetch.transform.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f62439c0832681ac7984ce500595