### PR TITLE
Update TRACER fetcher with contribution-only download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+tracer_data/
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ To ingest Colorado TRACER data run:
 python3 TRACERdata.fetch.transform.py
 ```
 
-This script downloads the public TRACER CSV files, parses them and appends them to the same `graph.json` file.
+This script downloads the public TRACER contribution CSV, parses it and appends
+the data to the same `graph.json` file. The default URL fetches the latest cycle,
+but you can set the `YEAR` environment variable to download a different election
+year back to 2020. The download is zipped and the script extracts the CSV automatically.
 
 API calls are retried automatically when rate limited. The tool waits up to three
 times for 60 seconds each and then performs one final retry after waiting an

--- a/TRACERdata.fetch.transform.py
+++ b/TRACERdata.fetch.transform.py
@@ -3,17 +3,20 @@ import json
 import os
 import hashlib
 import requests
+import zipfile
+from io import BytesIO
 
 # Enable debug logging when the DEBUG env var is set
 DEBUG = os.getenv('DEBUG', '1') == '1'
 # Toggle SSL certificate verification with VERIFY_SSL env var
 VERIFY_SSL = os.getenv('VERIFY_SSL', '1') == '1'
 
-TRACER_BASE_URL = 'https://tracer.sos.colorado.gov/PublicSite/Download.aspx'
-# CSV export endpoints for each entity type
-CANDIDATE_URL = f'{TRACER_BASE_URL}?type=candidates'
-COMMITTEE_URL = f'{TRACER_BASE_URL}?type=committees'
-CONTRIBUTION_URL = f'{TRACER_BASE_URL}?type=contributions'
+# Base directory listing the yearly bulk CSV downloads
+TRACER_BASE_URL = 'https://tracer.sos.colorado.gov/PublicSite/Docs/BulkDataDownloads'
+# Election year used when building the filenames
+YEAR = os.getenv('YEAR', '2025')
+# Download path for the yearly contributions dataset
+CONTRIBUTION_URL = f'{TRACER_BASE_URL}/{YEAR}_ContributionData.csv.zip'
 
 GRAPH_JSON_PATH = 'graph.json'
 
@@ -39,15 +42,21 @@ existing_edges = {(e['source'], e['target'], e['label']) for e in graph['edges']
 
 
 def download_file(url: str, dest: str) -> None:
-    """Download a remote file to the local filesystem."""
-    # Simple wrapper over requests.get for CSV downloads
+    """Download a (possibly zipped) CSV and save it to dest."""
     debug(f"Downloading {url} -> {dest}")
     resp = requests.get(url, verify=VERIFY_SSL)
     if resp.status_code != 200:
         print(f"Error {resp.status_code} fetching {url}")
         return
-    with open(dest, 'wb') as f:
-        f.write(resp.content)
+    if url.endswith('.zip'):
+        # Extract the first file from the zip archive in memory
+        with zipfile.ZipFile(BytesIO(resp.content)) as zf:
+            name = zf.namelist()[0]
+            with zf.open(name) as zipped_file, open(dest, 'wb') as f:
+                f.write(zipped_file.read())
+    else:
+        with open(dest, 'wb') as f:
+            f.write(resp.content)
 
 
 def make_contrib_id(name: str, addr: str) -> str:
@@ -57,50 +66,6 @@ def make_contrib_id(name: str, addr: str) -> str:
     return hashlib.sha1(concat.encode('utf-8')).hexdigest()
 
 
-def process_candidates(path: str) -> None:
-    """Read candidate data and add nodes."""
-    # Each row describes a campaign filing
-    debug(f"Processing candidates from {path}")
-    with open(path, newline='', encoding='utf-8-sig') as csvfile:
-        reader = csv.DictReader(csvfile)
-        for row in reader:
-            cid = row.get('FilerId') or row.get('candidate_id')
-            name = row.get('FilerName') or row.get('candidate_name')
-            if not cid or not name:
-                continue
-            if cid not in existing_node_ids:
-                graph['nodes'].append({
-                    'id': cid,
-                    'label': name,
-                    'type': 'Campaign',
-                    'attributes': [
-                        {'key': 'source', 'value': 'TRACER'}
-                    ]
-                })
-                existing_node_ids.add(cid)
-
-
-def process_committees(path: str) -> None:
-    """Read committee data and add nodes."""
-    # Committees represent campaign organizations
-    debug(f"Processing committees from {path}")
-    with open(path, newline='', encoding='utf-8-sig') as csvfile:
-        reader = csv.DictReader(csvfile)
-        for row in reader:
-            cmte_id = row.get('CommitteeId') or row.get('committee_id')
-            name = row.get('CommitteeName') or row.get('committee_name')
-            if not cmte_id or not name:
-                continue
-            if cmte_id not in existing_node_ids:
-                graph['nodes'].append({
-                    'id': cmte_id,
-                    'label': name,
-                    'type': 'Campaign',
-                    'attributes': [
-                        {'key': 'source', 'value': 'TRACER'}
-                    ]
-                })
-                existing_node_ids.add(cmte_id)
 
 
 def process_contributions(path: str) -> None:
@@ -130,7 +95,16 @@ def process_contributions(path: str) -> None:
                 })
                 existing_node_ids.add(contrib_id)
             if cmte not in existing_node_ids:
-                continue
+                # Create a committee node from contribution data
+                graph['nodes'].append({
+                    'id': cmte,
+                    'label': row.get('CommitteeName') or 'Committee',
+                    'type': 'Campaign',
+                    'attributes': [
+                        {'key': 'source', 'value': 'TRACER'}
+                    ]
+                })
+                existing_node_ids.add(cmte)
             edge_key = (contrib_id, cmte, 'contributed_to')
             if edge_key not in existing_edges:
                 graph['edges'].append({
@@ -146,20 +120,14 @@ def process_contributions(path: str) -> None:
                 existing_edges.add(edge_key)
 
 
-# Download files to local paths
-# Data files are saved in a temporary directory
+# Download the contribution file and process it
+# Data files are saved in a temporary directory and the zip archive is extracted
 os.makedirs('tracer_data', exist_ok=True)
-CANDIDATE_FILE = 'tracer_data/candidates.csv'
-COMMITTEE_FILE = 'tracer_data/committees.csv'
 CONTRIBUTION_FILE = 'tracer_data/contributions.csv'
 
-download_file(CANDIDATE_URL, CANDIDATE_FILE)
-download_file(COMMITTEE_URL, COMMITTEE_FILE)
 download_file(CONTRIBUTION_URL, CONTRIBUTION_FILE)
 
 # Process downloaded data
-process_candidates(CANDIDATE_FILE)
-process_committees(COMMITTEE_FILE)
 process_contributions(CONTRIBUTION_FILE)
 
 # Save updated graph
@@ -167,4 +135,4 @@ with open(GRAPH_JSON_PATH, 'w') as f:
     json.dump(graph, f, indent=2)
     debug('Graph updated with TRACER data')
 
-print('Graph updated with TRACER data from all sources.')
+print('Graph updated with TRACER contribution data.')


### PR DESCRIPTION
## Summary
- only download the yearly TRACER contribution file
- build committee nodes from the contribution data
- document the contribution-only fetcher in README

## Testing
- `python3 -m py_compile TRACERdata.fetch.transform.py`
- `python3 TRACERdata.fetch.transform.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849faca1cc883269628ba4b17183323