### PR TITLE
Handle TRACER CSV encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This script downloads the public TRACER contribution CSV, parses it and appends
 the data to the same `graph.json` file. The default URL fetches the latest cycle,
 but you can set the `YEAR` environment variable to download a different election
 year back to 2020. The download is zipped and the script extracts the CSV automatically.
+The CSV is encoded with Windows-1252, which the script reads automatically.
 
 API calls are retried automatically when rate limited. The tool waits up to three
 times for 60 seconds each and then performs one final retry after waiting an

--- a/TRACERdata.fetch.transform.py
+++ b/TRACERdata.fetch.transform.py
@@ -72,7 +72,8 @@ def process_contributions(path: str) -> None:
     """Read individual contributions and create edges."""
     # Link contributor nodes to the committees they support
     debug(f"Processing contributions from {path}")
-    with open(path, newline='', encoding='utf-8-sig') as csvfile:
+    # Use Windows-1252 to handle smart quotes and other non-UTF-8 chars
+    with open(path, newline='', encoding='cp1252') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             name = row.get('ContributorName') or row.get('contributor_name')


### PR DESCRIPTION
## Summary
- decode TRACER contribution CSV using cp1252 instead of UTF-8
- note Windows-1252 encoding in README

## Testing
- `python3 -m py_compile TRACERdata.fetch.transform.py`
- `python3 -m py_compile FECdata.fetch.transform.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0a0aaa8083268e0997eec12d1d29